### PR TITLE
DEV: Move error messages to config/locales

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,6 @@ class User < ApplicationRecord
             presence: true,
             comparison: {
               less_than_or_equal_to: 18.years.ago,
-              # TODO: implement locale error messages
-              message: 'You must be at least 18 years old to use this site.',
             }
 
   validates :display_name, presence: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module CriticalHit
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    # Set i18n default to English
+    config.i18n.default_locale = :en
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,12 @@
+en:
+  activerecord:
+    attributes:
+      errors:
+        models:
+          user:
+            attributes:
+              birth_date: "You must be at least 18 years old to use this site."
+
 # Files in the config/locales directory are used for internationalization
 # and are automatically loaded by Rails. If you want to use locales other
 # than English, add the necessary files in this directory.
@@ -28,6 +37,3 @@
 #
 # To learn more, please read the Rails Internationalization guide
 # available at https://guides.rubyonrails.org/i18n.html.
-
-en:
-  hello: "Hello world"


### PR DESCRIPTION
A quick fix PR to move error messages properly over to config/locales/en.yml